### PR TITLE
Fixed incorrect function call (missing 's')

### DIFF
--- a/choice_lib.py
+++ b/choice_lib.py
@@ -105,7 +105,7 @@ def choose_n_by_bin(data, binnable, n):
     return set(usable.variant)
   # ascribe bins
   bins = pred_bins()
-  usable['bin'] = bin_pred(usable[binnable], bins)
+  usable['bin'] = bin_preds(usable[binnable], bins)
   # choose guides for each bin (skipping 0)
   chosen = set()
   bins = list(range(NBINS))


### PR DESCRIPTION
Was getting an error after cloning the repo. Looks like bin_pred function call was missing an 's'. I changed that and it seems to be working now:

> Traceback (most recent call last):
>   File "choose_guides.py", line 97, in <module>
>     sys.exit(main())
>   File "choose_guides.py", line 88, in main
>     guides[locus] = cl.choose_n_by_pred(candidates, args.n)
>   File "/store/home/mad/PROJECTS/CRISPRi/gross_lab/mismatch_crispri/choice_lib.py", line 85, in choose_n_by_pred
>     return choose_n_by_bin(preds, 'y_pred', n)
>   File "/store/home/mad/PROJECTS/CRISPRi/gross_lab/mismatch_crispri/choice_lib.py", line 108, in choose_n_by_bin
>     usable['bin'] = bin_pred(usable[binnable], bins)
> NameError: name 'bin_pred' is not defined


```
>git grep bin_pred
choice_lib.py:def bin_preds(preds, bins):
choice_lib.py:  usable['bin'] = bin_pred(usable[binnable], bins)
```